### PR TITLE
amount が差し引き０になると０除算エラーがでる不具合修正

### DIFF
--- a/bin/zaif-log-parser
+++ b/bin/zaif-log-parser
@@ -57,7 +57,7 @@ def each(subtotal, v):
   else:
     subtotal_jpy = prev['subtotal_jpy'] + diff_amount * price - payed_price
   # 現時点の単価
-  unit_price = subtotal_jpy / amount
+  unit_price = subtotal_jpy / amount if amount != 0 else Decimal('0')
   # 現時点の利益(sellで初めて計上)
   diff_benefit=Decimal('0')
   if is_sell:

--- a/bin/zaif-log-parser
+++ b/bin/zaif-log-parser
@@ -10,6 +10,8 @@ import functools
 from decimal import *
 import simplejson as json
 
+ZERO = Decimal('0')
+
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
@@ -34,16 +36,16 @@ def each(subtotal, v):
   sign= (Decimal('-1') if is_sell else Decimal('1'))
   key = record['currency_pair']
   prev = subtotal[key] if key in subtotal else {
-    'amount': Decimal('0'), 
-    'subtotal_jpy': Decimal('0'), 
-    'unit_price': Decimal('0'),
-    'benefit': Decimal('0')
+    'amount': ZERO, 
+    'subtotal_jpy': ZERO, 
+    'unit_price': ZERO,
+    'benefit': ZERO
   }
   in_amount = Decimal(record['amount'])
   fee_amount = Decimal(record['fee_amount'])
   price = Decimal(record['price'])
   # bid のときは手数料が通貨単位で、買った量から差し引かれる
-  diff_amount = in_amount - (fee_amount if not is_sell else Decimal('0'))
+  diff_amount = in_amount - (fee_amount if not is_sell else ZERO)
   # ask のときは手数料が円単位
   payed_price = fee_amount if is_sell else fee_amount * price
   # 累積通貨資産
@@ -51,15 +53,15 @@ def each(subtotal, v):
   # 購入に使った累計JPY資産
   # 買ったとき: 追加＝購入金額 - 手数料
   # 売ったとき: 減少＝現在のsubtotal_jpyが何割減ったか＝(販売量+手数料) * 購入単価
-  subtotal_jpy = Decimal('0')
+  subtotal_jpy = ZERO
   if is_sell:
     subtotal_jpy = prev['subtotal_jpy'] - in_amount * prev['unit_price']
   else:
     subtotal_jpy = prev['subtotal_jpy'] + diff_amount * price - payed_price
   # 現時点の単価
-  unit_price = subtotal_jpy / amount if amount != 0 else Decimal('0')
+  unit_price = subtotal_jpy / amount if amount != 0 else ZERO
   # 現時点の利益(sellで初めて計上)
-  diff_benefit=Decimal('0')
+  diff_benefit=ZERO
   if is_sell:
     diff_benefit = diff_amount * (price - prev['unit_price'])
   benefit = prev['benefit'] + diff_benefit
@@ -82,7 +84,7 @@ def sum_benefit(total, v):
   if v[0].endswith("_btc"): return total
   return total + v[1]['benefit']
 
-result['total'] = {'benefit':functools.reduce(sum_benefit, result.items(), Decimal('0')) }
+result['total'] = {'benefit':functools.reduce(sum_benefit, result.items(), ZERO) }
 
 print(json.dumps(result, use_decimal=True))
 


### PR DESCRIPTION
 #1 の修正です。
#1 で上がっていたサンプルの結果で修正確認。
```
{"total": {"benefit": 14.35554000000007841876481495}, "zaif_jpy": {"unit_price": 0, "subtotal_jpy": -2E-25, "benefit": 14.35554000000007841876481495, "amount": 0E-25}}
```